### PR TITLE
Fix reactivity of list property

### DIFF
--- a/src/components/VirtualTree/index.tsx
+++ b/src/components/VirtualTree/index.tsx
@@ -151,7 +151,7 @@ export default defineComponent({
               class: ['vir-tree-wrap'],
               size: props.size,
               remain: props.remain,
-              list: flatList.value,
+              list: flatList,
               dataKey: 'nodeKey',
             }, {
               default: (data: { item: TreeNodeOptions, index: number }) => h(VirTreeNode, {

--- a/src/components/VirtualTree/index.tsx
+++ b/src/components/VirtualTree/index.tsx
@@ -39,7 +39,7 @@ export default defineComponent({
     const flatList = ref<TreeNodeOptions[]>([]);
     watch(() => props.source, newVal => {
       flatList.value = flattenTree(newVal);
-    }, { immediate: true });
+    }, { immediate: true, deep: true });
     const selectChange = (node: TreeNodeOptions) => {
       node.selected = !node.selected;
       if (selectedKey.value !== node.nodeKey) {
@@ -151,7 +151,7 @@ export default defineComponent({
               class: ['vir-tree-wrap'],
               size: props.size,
               remain: props.remain,
-              list: flatList,
+              list: flatList.value,
               dataKey: 'nodeKey',
             }, {
               default: (data: { item: TreeNodeOptions, index: number }) => h(VirTreeNode, {


### PR DESCRIPTION
Hi, guys! Please, check my changes. I found some problem with the reactivity of the `list` property, when I change the `source`  property of the tree component, the `list` property doesn't change, because it gets `.value` here.

```
h(VirtualList, {
  ...
  list: flatList.value,
  ...
}, ...
```
